### PR TITLE
[Feature] Add macOS support for SignInAppleAsync

### DIFF
--- a/Sources/SignInAppleAsync/Extensions/NSApplication+EXT.swift
+++ b/Sources/SignInAppleAsync/Extensions/NSApplication+EXT.swift
@@ -1,0 +1,19 @@
+//
+//  NSApplication+EXT.swift
+//  SignInAppleAsync
+//
+//  Created by Valentine Zubkov on 30.04.2025.
+//
+
+#if os(macOS)
+
+import AppKit
+
+extension NSApplication {
+    static func topViewController() -> NSViewController? {
+        let window = NSApplication.shared.windows.first { $0.isKeyWindow } ?? NSApplication.shared.windows.first
+        return window?.contentViewController
+    }
+}
+
+#endif

--- a/Sources/SignInAppleAsync/Extensions/UIApplication+EXT.swift
+++ b/Sources/SignInAppleAsync/Extensions/UIApplication+EXT.swift
@@ -4,6 +4,9 @@
 //
 //  Created by Nick Sarno on 9/29/24.
 //
+
+#if os(iOS)
+
 import UIKit
 
 extension UIApplication {
@@ -48,3 +51,5 @@ extension UIApplication {
     }
 
 }
+
+#endif

--- a/Sources/SignInAppleAsync/SignInWithAppleHelper+iOS.swift
+++ b/Sources/SignInAppleAsync/SignInWithAppleHelper+iOS.swift
@@ -1,0 +1,174 @@
+#if os(iOS)
+
+import Foundation
+import CryptoKit
+import AuthenticationServices
+import UIKit
+
+@MainActor
+public final class SignInWithAppleHelper: NSObject {
+
+    private var completionHandler: ((Result<SignInWithAppleResult, Error>) -> Void)?
+    private var currentNonce: String?
+    
+    /// Start Sign In With Apple and present OS modal.
+    ///
+    /// - Parameter viewController: ViewController to present OS modal on. If nil, function will attempt to find the top-most ViewController. Throws an error if no ViewController is found.
+    public func signIn(viewController: UIViewController? = nil) async throws -> SignInWithAppleResult {
+        for try await response in startSignInWithAppleFlow() {
+            return response
+        }
+        
+        throw SignInWithAppleError.failedToStartFlow
+    }
+
+    private func startSignInWithAppleFlow(viewController: UIViewController? = nil) -> AsyncThrowingStream<SignInWithAppleResult, Error> {
+        AsyncThrowingStream { continuation in
+            startSignInWithAppleFlow { result in
+                switch result {
+                case .success(let signInWithAppleResult):
+                    continuation.yield(signInWithAppleResult)
+                    continuation.finish()
+                    return
+                case .failure(let error):
+                    continuation.finish(throwing: error)
+                    return
+                }
+            }
+        }
+    }
+
+    private func startSignInWithAppleFlow(viewController: UIViewController? = nil, completion: @escaping (Result<SignInWithAppleResult, Error>) -> Void) {
+        guard let topVC = viewController ?? UIApplication.topViewController() else {
+            completion(.failure(SignInWithAppleError.noViewController))
+            return
+        }
+
+        let nonce = randomNonceString()
+        currentNonce = nonce
+        completionHandler = completion
+        showOSPrompt(nonce: nonce, on: topVC)
+    }
+
+}
+
+// MARK: PRIVATE
+private extension SignInWithAppleHelper {
+
+    // Adapted from https://auth0.com/docs/api-auth/tutorials/nonce#generate-a-cryptographically-random-nonce
+    private func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: [Character] =
+        Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0 ..< 16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode != errSecSuccess {
+                    fatalError(
+                        "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
+                    )
+                }
+                return random
+            }
+
+            randoms.forEach { random in
+                if remainingLength == 0 {
+                    return
+                }
+
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+
+        return result
+    }
+
+    private func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap {
+            String(format: "%02x", $0)
+        }.joined()
+
+        return hashString
+    }
+
+    private func showOSPrompt(nonce: String, on viewController: UIViewController) {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = sha256(nonce)
+
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = viewController
+
+        authorizationController.performRequests()
+    }
+
+    private enum SignInWithAppleError: LocalizedError {
+        case noViewController
+        case invalidCredential
+        case badResponse
+        case unableToFindNonce
+        case failedToStartFlow
+
+        var errorDescription: String? {
+            switch self {
+            case .noViewController:
+                return "Could not find top view controller."
+            case .invalidCredential:
+                return "Invalid sign in credential."
+            case .badResponse:
+                return "Apple Sign In had a bad response."
+            case .unableToFindNonce:
+                return "Apple Sign In token expired."
+            case .failedToStartFlow:
+                return "Apple SIgn In failed."
+            }
+        }
+    }
+
+}
+
+extension SignInWithAppleHelper: ASAuthorizationControllerDelegate {
+    nonisolated public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        Task { @MainActor in
+            do {
+                guard let currentNonce else {
+                    throw SignInWithAppleError.unableToFindNonce
+                }
+
+                guard let result = SignInWithAppleResult(authorization: authorization, nonce: currentNonce) else {
+                    throw SignInWithAppleError.badResponse
+                }
+
+                completionHandler?(.success(result))
+            } catch {
+                completionHandler?(.failure(error))
+                return
+            }
+        }
+    }
+    nonisolated public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        Task { @MainActor in
+            completionHandler?(.failure(error))
+            return
+        }
+    }
+}
+
+extension UIViewController: @retroactive ASAuthorizationControllerPresentationContextProviding {
+    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return self.view.window!
+    }
+ }
+
+#endif

--- a/Sources/SignInAppleAsync/SignInWithAppleHelper+macOS.swift
+++ b/Sources/SignInAppleAsync/SignInWithAppleHelper+macOS.swift
@@ -117,7 +117,7 @@ private extension SignInWithAppleHelper {
         authorizationController.delegate = self
         authorizationController.presentationContextProvider = viewController
 
-        Task { @MainActor in
+        Task(priority: .userInitiated) { @MainActor in
             authorizationController.performRequests()
         }
     }

--- a/Sources/SignInAppleAsync/SignInWithAppleHelper+macOS.swift
+++ b/Sources/SignInAppleAsync/SignInWithAppleHelper+macOS.swift
@@ -117,7 +117,9 @@ private extension SignInWithAppleHelper {
         authorizationController.delegate = self
         authorizationController.presentationContextProvider = viewController
 
-        authorizationController.performRequests()
+        Task { @MainActor in
+            authorizationController.performRequests()
+        }
     }
 
     private enum SignInWithAppleError: LocalizedError {

--- a/Sources/SignInAppleAsync/SignInWithAppleHelper+macOS.swift
+++ b/Sources/SignInAppleAsync/SignInWithAppleHelper+macOS.swift
@@ -1,7 +1,16 @@
+//
+//  SignInWithAppleHelper+macOS.swift
+//  SignInAppleAsync
+//
+//  Created by Valentine Zubkov on 30.04.2025.
+//
+
+#if os(macOS)
+
 import Foundation
 import CryptoKit
 import AuthenticationServices
-import UIKit
+import AppKit
 
 @MainActor
 public final class SignInWithAppleHelper: NSObject {
@@ -12,7 +21,7 @@ public final class SignInWithAppleHelper: NSObject {
     /// Start Sign In With Apple and present OS modal.
     ///
     /// - Parameter viewController: ViewController to present OS modal on. If nil, function will attempt to find the top-most ViewController. Throws an error if no ViewController is found.
-    public func signIn(viewController: UIViewController? = nil) async throws -> SignInWithAppleResult {
+    public func signIn(viewController: NSViewController? = nil) async throws -> SignInWithAppleResult {
         for try await response in startSignInWithAppleFlow() {
             return response
         }
@@ -20,7 +29,7 @@ public final class SignInWithAppleHelper: NSObject {
         throw SignInWithAppleError.failedToStartFlow
     }
 
-    private func startSignInWithAppleFlow(viewController: UIViewController? = nil) -> AsyncThrowingStream<SignInWithAppleResult, Error> {
+    private func startSignInWithAppleFlow(viewController: NSViewController? = nil) -> AsyncThrowingStream<SignInWithAppleResult, Error> {
         AsyncThrowingStream { continuation in
             startSignInWithAppleFlow { result in
                 switch result {
@@ -36,8 +45,8 @@ public final class SignInWithAppleHelper: NSObject {
         }
     }
 
-    private func startSignInWithAppleFlow(viewController: UIViewController? = nil, completion: @escaping (Result<SignInWithAppleResult, Error>) -> Void) {
-        guard let topVC = viewController ?? UIApplication.topViewController() else {
+    private func startSignInWithAppleFlow(viewController: NSViewController? = nil, completion: @escaping (Result<SignInWithAppleResult, Error>) -> Void) {
+        guard let topVC = viewController ?? NSApplication.topViewController() else {
             completion(.failure(SignInWithAppleError.noViewController))
             return
         }
@@ -98,7 +107,7 @@ private extension SignInWithAppleHelper {
         return hashString
     }
 
-    private func showOSPrompt(nonce: String, on viewController: UIViewController) {
+    private func showOSPrompt(nonce: String, on viewController: NSViewController) {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()
         request.requestedScopes = [.fullName, .email]
@@ -163,8 +172,11 @@ extension SignInWithAppleHelper: ASAuthorizationControllerDelegate {
     }
 }
 
-extension UIViewController: @retroactive ASAuthorizationControllerPresentationContextProviding {
+extension NSViewController: @retroactive ASAuthorizationControllerPresentationContextProviding {
     public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         return self.view.window!
     }
  }
+
+
+#endif


### PR DESCRIPTION
This package is now compatible with macOS. Those who build single-target multi-platform apps, will find this update useful.

**Known issue:**
Concurrency-related warning for the showOSPrompt function in SignInWithAppleHelper, when it executes this request authorizationController.performRequests().
